### PR TITLE
add flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,35 @@ pip install kebihelp
 kebihelp show -a
 ```
 
+## Nix Flake
+
+This package is available as flake.
+
+Add the flake inputs to your `flake.nix`
+
+```nix
+# flake.nix
+inputs = {
+    kebihelp.url = "github:juienpro/kebihelp"
+};
+```
+
+For use with home-manager,
+
+```nix
+{ inputs, pkgs, ...}:
+
+home.package = [ inputs.kebihelp.packages.${pkgs.system}.default ]
+```
+
+For use with nixOS,
+
+```nix
+{ inputs, pkgs, ...}:
+
+environment.systemPackages = [ inputs.kebihelp.packages.${pkgs.system}.default ]
+```
+
 ## Usage
 
 The code is a Python 3 script using PyQT5. You just need to clone this repository and run `pip3 install -r requirements.txt`.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, pkgs
+, python3
+}:
+python3.pkgs.buildPythonPackage rec {
+  pname = "kebihelp";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+    pkgs.qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    pkgs.qt5.qtbase
+    pkgs.qt5.qtwayland
+    pkgs.qt5.qttools
+    pkgs.qt5.qtdeclarative
+  ];
+
+
+  propagatedBuildInputs = [
+    python3.pkgs.prettytable
+    python3.pkgs.pyqt5
+    python3.pkgs.pyqt5-sip
+  ];
+
+  pythonImportsCheck = [ "kebihelp" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/kebihelp \
+      --prefix PYTHONPATH : $out/lib/python3.11/site-packages:${pkgs.python311Packages.prettytable}/lib/python3.11/site-packages:${pkgs.python311Packages.pyqt5}/lib/python3.11/site-packages:${pkgs.python311Packages.pyqt5_sip}/lib/python3.11/site-packages:${pkgs.python311Packages.wcwidth}/lib/python3.11/site-packages
+  '';
+
+  meta = with lib; {
+    description = "A universal Keybinding helper written in Python and QT5";
+    homepage = "https://github.com/juienpro/kebihelp";
+    changelog = "https://github.com/juienpro/kebihelp/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    # maintainers = with maintainers; [ ];
+    mainProgram = "kebihelp";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718895438,
+        "narHash": "sha256-k3JqJrkdoYwE3fHE6xGDY676AYmyh4U2Zw+0Bwe5DLU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d603719ec6e294f034936c0d0dc06f689d91b6c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "kebihelp flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      pkgsFor = nixpkgs.legacyPackages;
+    in
+    {
+      packages = forAllSystems (system: {
+        default = self.packages.${system}.kebihelp;
+        kebihelp = pkgsFor.${system}.callPackage ./default.nix { };
+      });
+
+      defaultPackage = forAllSystems (system: self.packages.${system}.default);
+    };
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,20 @@
 [project]
 name = "kebihelp"
 version = "0.1.2"
-authors = [
-    { name="Julien Pro", email="contact@julienpro.com"}
-]
+authors = [{ name = "Julien Pro", email = "contact@julienpro.com" }]
 description = "A Linux universal keybindings helper written in Python/QT5"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = [
-    "prettytable>=3.10.0",
-    "PyQt5>=5.15.10",
-    "PyQt5_sip>=12.13.0"
-]
+dependencies = ["prettytable>=3.9.0", "PyQt5>=5.15.9", "PyQt5_sip>=12.13.0"]
 classifiers = [
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Operating System :: POSIX :: Linux",
-    "Topic :: System :: Operating System",
-    "Topic :: System :: Systems Administration",
-    "Topic :: Desktop Environment"
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Operating System :: POSIX :: Linux",
+  "Topic :: System :: Operating System",
+  "Topic :: System :: Systems Administration",
+  "Topic :: Desktop Environment",
 ]
 
 [project.urls]
@@ -33,4 +27,3 @@ kebihelp = "kebihelp.main:main"
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
-

--- a/src/kebihelp/config.py
+++ b/src/kebihelp/config.py
@@ -6,7 +6,7 @@ from prettytable import PrettyTable
 # import libs.Group as Group
 # import libs.Shortcut as Shortcut
 
-CONFIG_FILE = "~/.config/kebihelp.json"
+CONFIG_FILE = "~/.config/kebihelp/conf.json"
 
 class Config():
     def __init__(self):

--- a/src/kebihelp/config.py
+++ b/src/kebihelp/config.py
@@ -6,7 +6,7 @@ from prettytable import PrettyTable
 # import libs.Group as Group
 # import libs.Shortcut as Shortcut
 
-CONFIG_FILE = "~/.config/kebihelp/conf.json"
+CONFIG_FILE = "~/.config/kebihelp/kebihelp.json"
 
 class Config():
     def __init__(self):


### PR DESCRIPTION
This pull request adds a flake to the repo. The file `flake.nix` references `default.nix`, which is the actual build specifications for the package.

The `README.md` is updated with installation instructions via the flake.

Dependency requirements for prettytable and PyQt5 in `project.toml` were degraded for compatibility with the flake. `nixpkgs-unstable` is using `prettytable 3.9.0` and `PyQt5 5.15.9`. 