### PR TITLE
Fix display of keys in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Kebihelp is an universal key-bindings helper for Linux, written in Python and in
 Click on the picture to zoom.
 
 In this demo:
-- <F1> displays the helper
-- <TAB> key is used to cycle through the tabs.
-- <ESC> or <q> is used to close it
+- `<F1>` displays the helper
+- `<TAB>` key is used to cycle through the tabs.
+- `<ESC>` or `<q>` is used to close it
 
 ## Features
 


### PR DESCRIPTION
The demo section has keys like `<F1>` and `<Tab>` without tildes around them, which results in them looking like HTML elements that don't exist, so GitHub doesn't display them. This PR fixes that so that they will display properly in the README.